### PR TITLE
GR static toxic update

### DIFF
--- a/SRC/python/gr50/__init__.py
+++ b/SRC/python/gr50/__init__.py
@@ -343,7 +343,6 @@ def gr_metrics(data, alpha=0.05):
     return df
 
 
-
 def compute_gr_static_toxic(data, time_col='timepoint'):
     """
     Computes gr_static and gr_toxic values for a given dataframe.
@@ -413,13 +412,13 @@ def compute_gr_static_toxic(data, time_col='timepoint'):
         ((1 + d_ratio__ctrl) * gr__ctrl)
         ) - 1
 
-    gr_death = 2 ** (
+    gr_toxic = 2 ** (
         (d_ratio__ctrl * gr__ctrl - d_ratio * gr)/
          x[time_col]
         ) - 1
 
     x['GR_static'] = gr_static
-    x['GR_toxic'] = gr_death
+    x['GR_toxic'] = gr_toxic
     
     return x
 

--- a/SRC/python/gr50/__init__.py
+++ b/SRC/python/gr50/__init__.py
@@ -225,6 +225,7 @@ def _mklist(values):
         return [values]
 
 def _metrics(df, alpha):
+    df = df.sort_values(by='concentration')
     conc_min = df.concentration.min() / 100
     conc_max = df.concentration.max() * 100
     bounds = np.array([[-1, 1], np.log10([conc_min, conc_max]), [0.1, 5]])

--- a/SRC/python/gr50/__init__.py
+++ b/SRC/python/gr50/__init__.py
@@ -14,7 +14,8 @@ except ImportError:
     _packages_available = False
 
 
-__all__ = ['compute_gr', 'compute_gr_single', 'gr_metrics', 'logistic']
+__all__ = ['compute_gr', 'compute_gr_single', 'gr_metrics', 'logistic',
+           'compute_gr_static_toxic']
 logger = logging.getLogger(__name__)
 
 

--- a/SRC/python/gr50/__init__.py
+++ b/SRC/python/gr50/__init__.py
@@ -357,6 +357,7 @@ def compute_gr_static_toxic(data, time_col='timepoint'):
     * dead_count__ctrl: Total number of dead cells in the no-perturbation control.
     * timepoint : duration of drug treatment per column. The column name can be passed as an argument to
                  allow flexibility of passing time in any units (typically hours or days).
+    * role : column that specifies if the sample is 'negative_control', 'positive_control', or 'treatment'.
 
     Parameters
     ----------

--- a/SRC/python/gr50/__init__.py
+++ b/SRC/python/gr50/__init__.py
@@ -395,7 +395,7 @@ def compute_gr_static_toxic(data, time_col='timepoint'):
                                           1)
                                          )
     logger.warning("%d wells or conditions have 5%% fewer cells than time0 control,"
-                   "estimate of dead_count has been increased to compensate." % np.count_nonzero(mc))
+                   " estimate of dead_count has been increased to compensate." % np.count_nonzero(mc))
 
     # If total number of cells (live+dead) is more than 115% of untreated control,
     # then reduce estimate of dead cell count such that total cells is equal to
@@ -412,7 +412,7 @@ def compute_gr_static_toxic(data, time_col='timepoint'):
                                            1)
                                           )
     logger.warning("%d wells or conditions have too many cells relative to untreated control,"
-                   "estimate of dead_count has been reduced to compensate." % np.count_nonzero(hd)
+                   " estimate of dead_count has been reduced to compensate." % np.count_nonzero(hd)
                    )
     
     d_ratio = np.maximum(x.dead_count - x.dead_count__time0, 1)/\
@@ -440,7 +440,7 @@ def compute_gr_static_toxic(data, time_col='timepoint'):
     fe = (np.abs(x.cell_count - x.cell_count__time0)/x.cell_count) < 1e-10
     if np.any(fe):
          logger.warning("%d wells or conditions have live cell counts approximately equal to time0 control,"
-                        "therefore GR static and toxic values computed numerically using Taylor expansion." %
+                        " therefore GR static and toxic values computed numerically using Taylor expansion." %
                         np.count_nonzero(fe)
                         )
          x_gr = pd.DataFrame(list(zip(gr, gr__ctrl , d_ratio__ctrl)),
@@ -462,7 +462,7 @@ def compute_gr_static_toxic(data, time_col='timepoint'):
                  (1/b + np.diag(
                      np.dot(
                          np.power(counts_delta_rep_nterms, ts_exponents_rep_a),
-                         (counts_time0_rep_nterms * ts_exponents_rep_b).T
+                         np.power(counts_time0_rep_nterms, ts_exponents_rep_b).T
                          )
                      ).reshape(len(b), 1)
                   ).flatten()

--- a/SRC/python/gr50/__init__.py
+++ b/SRC/python/gr50/__init__.py
@@ -262,7 +262,8 @@ def _metrics(df, alpha, gr_value='GRvalue'):
     aoc = np.trapz(1 - df[gr_value], log_conc) / aoc_width
     return [gr50, max_, aoc, gec50, inf, slope, r2, pval]
 
-def gr_metrics(data, alpha=0.05, gr_value='GRvalue'):
+def gr_metrics(data, alpha=0.05, gr_value='GRvalue',
+               keys=['cell_line', 'agent', 'timepoint']):
     """Compute Growth Response metrics for an entire dataset.
 
     The input dataframe must contain a column named 'concentration' with the
@@ -333,11 +334,11 @@ def gr_metrics(data, alpha=0.05, gr_value='GRvalue'):
     if not _packages_available:
         raise RuntimeError("Please install numpy, scipy and pandas in order "
                            "to use this function")
-    non_keys = set(('concentration', 'cell_count', 'cell_count__ctrl',
-                    'cell_count__time0', 'GRvalue'))
+    #non_keys = set(('concentration', 'cell_count', 'cell_count__ctrl',
+    #               'cell_count__time0', 'GRvalue'))
     metric_columns = ['GR50', 'GRmax', 'GR_AOC', 'GEC50', 'GRinf', 'h_GR', 'r2_GR',
                       'pval_GR']
-    keys = list(set(data.columns) - non_keys)
+    #keys = list(set(data.columns) - non_keys)
     gb = data.groupby(keys)
     data = [_mklist(k) + _metrics(v, alpha, gr_value) for k, v in gb]
     df = pd.DataFrame(data, columns=keys + metric_columns)

--- a/SRC/python/gr50/__init__.py
+++ b/SRC/python/gr50/__init__.py
@@ -452,13 +452,17 @@ def compute_gr_static_toxic(data, time_col='timepoint'):
          b = b.reshape(len(b), 1)
          nterms = 35 # Number of terms in Taylor expansion series
          
+         counts_delta_rep_nterms = np.matlib.repmat((-1) * (a-b), 1, nterms)
+         ts_exponents_rep_a =  np.matlib.repmat(range(1, nterms+1), len(a), 1)
+         counts_time0_rep_nterms = np.matlib.repmat(b, 1, nterms)
+         ts_exponents_rep_b =  np.matlib.repmat(range(1, nterms+1), len(b), 1)
+         
          x_gr.loc[fe, 'd_ratio__gr'] = (
              np.maximum(x.loc[fe, 'dead_count'] - x.loc[fe, 'dead_count__time0'], 1).multiply(
                  (1/b + np.diag(
                      np.dot(
-                         np.power(np.matlib.repmat((-1) * (a-b), 1, nterms),
-                                  np.matlib.repmat(range(1, nterms+1), len(a), 1)),
-                         (np.matlib.repmat(b, 1, nterms) * np.matlib.repmat(range(1, nterms+1), len(b), 1)).T
+                         np.power(counts_delta_rep_nterms, ts_exponents_rep_a),
+                         (counts_time0_rep_nterms * ts_exponents_rep_b).T
                          )
                      ).reshape(len(b), 1)
                   ).flatten()


### PR DESCRIPTION
This PR extends and generalizes the existing codebase to include computation of GR static, toxic values and associated GR metrics.
 - `compute_gr_static_toxic` is a new feature for computing GR static and toxic values from live and dead cell counts, extending on the work begun in pull request #38.
 - `gr_metrics` and `_metrics` functions now takes `gr_value`  as an argument to specify which GR value (GRvalue, GR_static, GR_toxic) the metrics have to computed on. 
 - The number of non-key columns in the input dataframe have increased to include several additional columns relating to death counts, cell cycle fractions etc. Given that, I thought it was easier to specify the columns by which to group the input dataframe  as an argument to `gr_metrics`. 
 - In `_metrics`, the input dataframe is first sorted by concentration so that GRmax values are computed correctly. 

